### PR TITLE
[APAM-27] Expose session id and request buffer time

### DIFF
--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -1,0 +1,43 @@
+name: Build XCFramework
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-xcframework:
+    runs-on: macos-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Build .framework for iOS devices
+      run: xcodebuild archive \
+             -scheme AirwallexRisk \
+             -sdk iphoneos \
+             -destination 'generic/platform=iOS' \
+             -archivePath './build/device.xcarchive' \
+             SKIP_INSTALL=NO \
+             BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+    - name: Build .framework for iOS simulator
+      run: xcodebuild archive \
+             -scheme AirwallexRisk \
+             -sdk iphonesimulator \
+             -destination 'generic/platform=iOS Simulator' \
+             -archivePath './build/simulator.xcarchive' \
+             SKIP_INSTALL=NO \
+             BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+
+    - name: Create XCFramework
+      run: xcodebuild -create-xcframework \
+             -framework ./build/device.xcarchive/Products/Library/Frameworks/AirwallexRisk.framework \
+             -framework ./build/simulator.xcarchive/Products/Library/Frameworks/AirwallexRisk.framework \
+             -output ./build/AirwallexRisk.xcframework
+
+    - name: Upload XCFramework
+      uses: actions/upload-artifact@v4
+      with:
+        name: YourFramework.xcframework
+        path: ./build/YourFramework.xcframework
+        retention-days: 30

--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Build .framework for iOS devices
-      run: xcodebuild archive \
+      run: BUILD_FOR_XCFRAMEWORK=true xcodebuild archive \
              -scheme AirwallexRisk \
              -sdk iphoneos \
              -destination 'generic/platform=iOS' \
@@ -21,7 +21,7 @@ jobs:
              BUILD_LIBRARY_FOR_DISTRIBUTION=YES
 
     - name: Build .framework for iOS simulator
-      run: xcodebuild archive \
+      run: BUILD_FOR_XCFRAMEWORK=true xcodebuild archive \
              -scheme AirwallexRisk \
              -sdk iphonesimulator \
              -destination 'generic/platform=iOS Simulator' \

--- a/AirwallexRiskExample/AirwallexRiskExample/AirwallexRiskExampleApp.swift
+++ b/AirwallexRiskExample/AirwallexRiskExample/AirwallexRiskExampleApp.swift
@@ -12,7 +12,7 @@ import AirwallexRisk
 @main
 struct AirwallexRiskExampleApp: App {
     init() {
-        AirwallexRisk.start(
+        Risk.start(
             accountID: "YOUR_ACCOUNT_ID",
             with: .init(isProduction: false)
         )

--- a/AirwallexRiskExample/AirwallexRiskExample/AirwallexRiskExampleApp.swift
+++ b/AirwallexRiskExample/AirwallexRiskExample/AirwallexRiskExampleApp.swift
@@ -12,7 +12,7 @@ import AirwallexRisk
 @main
 struct AirwallexRiskExampleApp: App {
     init() {
-        Risk.start(
+        AirwallexRisk.start(
             accountID: "YOUR_ACCOUNT_ID",
             with: .init(isProduction: false)
         )

--- a/AirwallexRiskExample/AirwallexRiskExample/AuthService.swift
+++ b/AirwallexRiskExample/AirwallexRiskExample/AuthService.swift
@@ -20,8 +20,8 @@ class AuthService {
     func login(username: String, password: String) -> User {
         // When the user logs in, set the user id and log the login event.
         let user = User(id: UUID().uuidString, username: username)
-        AirwallexRisk.set(userID: user.id)
-        AirwallexRisk.log(event: "login")
+        Risk.set(userID: user.id)
+        Risk.log(event: "login")
         return user
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "AirwallexRisk",
+            type: .dynamic,
             targets: ["AirwallexRisk"]
         ),
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,10 @@
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
+import Foundation
+
+let buildForXCFramework = ProcessInfo.processInfo.environment["BUILD_FOR_XCFRAMEWORK"] == "true"
+let libraryType: Product.Library.LibraryType? = buildForXCFramework ? .dynamic : nil
 
 let package = Package(
     name: "AirwallexRisk",
@@ -11,7 +15,7 @@ let package = Package(
     products: [
         .library(
             name: "AirwallexRisk",
-            type: .dynamic,
+            type: libraryType,
             targets: ["AirwallexRisk"]
         ),
     ],

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ import AirwallexRisk
 class AppDelegate {
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    AirwallexRisk.start(
+    Risk.start(
       accountID: "YOUR_ACCOUNT_ID", // Required
       with: AirwallexRiskConfiguration(isProduction: true)
     )
@@ -57,7 +57,7 @@ class AppDelegate {
 
 **Notes**: 
 - `accountID` is required in all Airwallex scale customer apps. This will be your Airwallex account ID.
-- the optional `AirwallexRiskConfiguration` may also be used if needed. For test/debug builds you can set `isProduction: false`.
+- the optional `AirwallexRiskConfiguration` may also be used if needed. For test/debug builds you can set `isProduction: false` or `environment: .staging/.demo`. You can also customise the frequency of sending logs by `bufferTimeInterval: 5`.  
 
 #### Update user
 
@@ -68,7 +68,7 @@ After the app user signs in to their Airwallex account, the app must send the us
 ```swift
 import AirwallexRisk
 
-AirwallexRisk.set(userID: "USER_ID")
+Risk.set(userID: "USER_ID")
 ```
   
 #### Events
@@ -82,7 +82,7 @@ Use the following snippet to send event name and current screen name.
 ```swift
 import AirwallexRisk
 
-AirwallexRisk.log(
+Risk.log(
   event: "EVENT_NAME",
   screen: "SCREEN_NAME"
 )
@@ -95,7 +95,7 @@ When your app sends a request to Airwallex, you must add the provided header int
 ```swift
 import AirwallexRisk
 
-guard let header = AirwallexRisk.header else {
+guard let header = Risk.header else {
   return
 }
 var request = URLRequest(url: URL(string: "https://www.airwallex.com/...")!)
@@ -114,3 +114,13 @@ request.setAirwallexHeader()
 The header consists of
 - the field, which will always be `"x-risk-device-id"`, and
 - the value, which will be an internally generated device identifier.
+
+#### Session ID
+
+You can get the unique ID per app running session and provide it into Airwallex requests if needed (optional).
+
+```swift
+import AirwallexRisk
+
+let sessionID = Risk.SessionID
+```

--- a/Sources/AirwallexRisk/AirwallexRiskConfiguration.swift
+++ b/Sources/AirwallexRisk/AirwallexRiskConfiguration.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 /// AirwallexRisk configuration. Can be passed in as a parameter of ``AirwallexRisk/AirwallexRisk/start(accountID:with:)`` to configure the SDK.
-public struct AirwallexRiskConfiguration {
+@objc public class AirwallexRiskConfiguration: NSObject {
     let environment: AirwallexRiskEnvironment
     let tenant: Tenant
 
@@ -18,11 +18,24 @@ public struct AirwallexRiskConfiguration {
     /// - Parameters:
     ///   - isProduction: Set to false for pre-production or test builds.
     ///   - tenant: Do not modify unless requested by Airwallex.
-    public init(
+    public convenience init(
         isProduction: Bool = true,
         tenant: Tenant = .scale
     ) {
-        self.environment = isProduction ? .production : .demo
+        self.init(environment: isProduction ? .production : .demo, tenant: tenant)
+    }
+    
+    /// AirwallexRisk configuration options.
+    ///
+    /// Assigned when starting the SDK with ``AirwallexRisk/AirwallexRisk/start(accountID:with:)``.
+    /// - Parameters:
+    ///   - environment: Airwallex risk environment, set to production for release builds.
+    ///   - tenant: Airwallex risk SDK tenant.
+    public init(
+        environment: AirwallexRiskEnvironment,
+        tenant: Tenant
+    ) {
+        self.environment = environment
         self.tenant = tenant
     }
 }

--- a/Sources/AirwallexRisk/AirwallexRiskConfiguration.swift
+++ b/Sources/AirwallexRisk/AirwallexRiskConfiguration.swift
@@ -11,6 +11,7 @@ import Foundation
 @objc public class AirwallexRiskConfiguration: NSObject {
     let environment: AirwallexRiskEnvironment
     let tenant: Tenant
+    let bufferTimeInterval: TimeInterval
 
     /// AirwallexRisk configuration options.
     ///
@@ -32,10 +33,12 @@ import Foundation
     ///   - environment: Airwallex risk environment, set to production for release builds.
     ///   - tenant: Airwallex risk SDK tenant.
     public init(
-        environment: AirwallexRiskEnvironment,
-        tenant: Tenant
+        environment: AirwallexRiskEnvironment = .production,
+        tenant: Tenant = .scale,
+        bufferTimeInterval: TimeInterval = 20
     ) {
         self.environment = environment
         self.tenant = tenant
+        self.bufferTimeInterval = bufferTimeInterval
     }
 }

--- a/Sources/AirwallexRisk/AirwallexRiskConstants.swift
+++ b/Sources/AirwallexRisk/AirwallexRiskConstants.swift
@@ -15,10 +15,6 @@ enum AirwallexValue {
     static let contentJSON = "application/json"
     static let scheme = "https"
     static let notStartedWarning = "Please call `AirwallexRisk.start()` on app launch."
-
-    static func timeInterval(context: AirwallexRiskContext) -> TimeInterval {
-        context.environment == .production ? 20 : 5
-    }
 }
 
 enum AirwallexKey {

--- a/Sources/AirwallexRisk/AirwallexRiskEnvironment.swift
+++ b/Sources/AirwallexRisk/AirwallexRiskEnvironment.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-enum AirwallexRiskEnvironment {
+@objc public enum AirwallexRiskEnvironment: Int {
     case production
     case demo
     case staging

--- a/Sources/AirwallexRisk/Context/Tenant.swift
+++ b/Sources/AirwallexRisk/Context/Tenant.swift
@@ -9,11 +9,24 @@
 import Foundation
 
 /// Airwallex risk SDK tenant. Do not modify unless requested by Airwallex.
-public enum Tenant: String, Codable {
+@objc public enum Tenant: Int, Codable {
     /// Reserved for the Airwallex mobile app.
-    case `internal` = "Mobile app"
+    case `internal`
     /// Use with the Airwallex payment SDK.
-    case pa = "PA checkout"
+    case pa
     /// Default tenant for most users.
-    case scale = "Scale"
+    case scale
+    
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        let tenant = switch self {
+        case .internal:
+            "Mobile app"
+        case .pa:
+            "PA checkout"
+        case .scale:
+            "Scale"
+        }
+        try container.encode(tenant)
+    }
 }

--- a/Sources/AirwallexRisk/Events/EventManager.swift
+++ b/Sources/AirwallexRisk/Events/EventManager.swift
@@ -23,7 +23,8 @@ class EventManager: EventManagerType {
     convenience init(
         context: AirwallexRiskContext,
         repository: any RepositoryType<Event> = EventRepository(),
-        session: URLSession = .shared
+        session: URLSession = .shared,
+        timeInterval: TimeInterval
     ) {
         self.init(
             repository: repository,
@@ -32,7 +33,7 @@ class EventManager: EventManagerType {
                 context: context
             ),
             eventScheduler: EventScheduler(
-                timeInterval: AirwallexValue.timeInterval(context: context)
+                timeInterval: timeInterval
             ),
             automaticEventProvider: AutomaticEventProvider(
                 repository: repository,

--- a/Sources/AirwallexRisk/Header/URLRequest+Header.swift
+++ b/Sources/AirwallexRisk/Header/URLRequest+Header.swift
@@ -11,7 +11,7 @@ import Foundation
 extension URLRequest {
     /// Convenience method to attach the Airwallex risk header to any URLRequest.
     public mutating func setAirwallexHeader() {
-        guard let header = AirwallexRisk.header else {
+        guard let header = Risk.header else {
             return
         }
         setValue(

--- a/Sources/AirwallexRisk/Risk+Shared.swift
+++ b/Sources/AirwallexRisk/Risk+Shared.swift
@@ -8,17 +8,17 @@
 
 import Foundation
 
-extension AirwallexRisk {
-    /// Shared instance of ``AirwallexRisk``.
-    private static var shared: AirwallexRisk?
+extension Risk {
+    /// Shared instance of ``Risk``.
+    private static var shared: Risk?
 
-    /// Starts the shared ``AirwallexRisk`` SDK instance.
+    /// Starts the shared ``Risk`` SDK instance.
     ///
     /// - Parameters:
     ///   - accountID: Airwallex account ID for app customer. Required for all scale customers.
     ///   - configuration: ``AirwallexRiskConfiguration`` can be passed in if additional configuration is needed. Set `isProduction` to `false` for test builds.
     /// - Remark: Must be called once, as early as possible in the apps lifecycle.
-    public static func start(
+    @objc public static func start(
         accountID: String?,
         with configuration: AirwallexRiskConfiguration = .init()
     ) {
@@ -42,7 +42,7 @@ extension AirwallexRisk {
     /// Use this method if the account ID changes after calling ``start(accountID:with:)``. This method is unneeded by most users.
     /// - Parameters:
     ///   - accountID: Airwallex account ID. Set `nil` if unavailable.
-    public static func set(accountID: String?) {
+    @objc public static func set(accountID: String?) {
         guard let shared else {
             print(AirwallexValue.notStartedWarning)
             return
@@ -55,7 +55,7 @@ extension AirwallexRisk {
     /// Use this method after user sign in/out to store the user ID to be sent with events.
     /// - Parameters:
     ///   - userID: Signed in Airwallex user ID. Set `nil` on sign out.
-    public static func set(userID: String?) {
+    @objc public static func set(userID: String?) {
         guard let shared else {
             print(AirwallexValue.notStartedWarning)
             return
@@ -69,7 +69,7 @@ extension AirwallexRisk {
     /// - Parameters:
     ///   - event: App event that triggered this method call.
     ///   - screen: Current app view. Optional.
-    public static func log(
+    @objc public static func log(
         event: String,
         screen: String? = nil
     ) {

--- a/Sources/AirwallexRisk/Risk+Shared.swift
+++ b/Sources/AirwallexRisk/Risk+Shared.swift
@@ -33,7 +33,10 @@ extension Risk {
         )
         shared = .init(
             context: context,
-            eventManager: EventManager(context: context)
+            eventManager: EventManager(
+                context: context,
+                timeInterval: configuration.bufferTimeInterval
+            )
         )
     }
 

--- a/Sources/AirwallexRisk/Risk+Shared.swift
+++ b/Sources/AirwallexRisk/Risk+Shared.swift
@@ -97,4 +97,13 @@ extension Risk {
         }
         return shared.header
     }
+    
+    /// Airwallex session ID. Unique per app run.
+    @objc public static var sessionID: UUID? {
+        guard let shared else {
+            print(AirwallexValue.notStartedWarning)
+            return nil
+        }
+        return shared.sessionID
+    }
 }

--- a/Sources/AirwallexRisk/Risk.swift
+++ b/Sources/AirwallexRisk/Risk.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class AirwallexRisk {
+public class Risk {
     private let context: AirwallexRiskContext
     private let eventManager: EventManagerType
 

--- a/Sources/AirwallexRisk/Risk.swift
+++ b/Sources/AirwallexRisk/Risk.swift
@@ -29,6 +29,11 @@ public class Risk {
             value: context.deviceID.wrappedValue.uuidString
         )
     }
+    
+    /// Airwallex session ID. Unique per app run.
+    var sessionID: UUID {
+        context.sessionID
+    }
 
     /// Sets the Airwallex  account ID.
     ///

--- a/Tests/AirwallexRiskTests/AirwallexRiskConfigurationTests.swift
+++ b/Tests/AirwallexRiskTests/AirwallexRiskConfigurationTests.swift
@@ -10,15 +10,21 @@ import XCTest
 @testable import AirwallexRisk
 
 final class AirwallexRiskConfigurationTests: XCTestCase {
-    func testDefaultInit() {
+    func testConvenienceInit() {
         let config = AirwallexRiskConfiguration()
         XCTAssertEqual(config.environment, .production)
         XCTAssertEqual(config.tenant, .scale)
     }
 
-    func testCustomInit() {
+    func testCustomConvenienceInit() {
         let config = AirwallexRiskConfiguration(isProduction: false, tenant: .internal)
         XCTAssertEqual(config.environment, .demo)
         XCTAssertEqual(config.tenant, .internal)
+    }
+    
+    func testCustomInit() {
+        let config = AirwallexRiskConfiguration(environment: .staging, tenant: .pa)
+        XCTAssertEqual(config.environment, .staging)
+        XCTAssertEqual(config.tenant, .pa)
     }
 }

--- a/Tests/AirwallexRiskTests/AirwallexRiskTests.swift
+++ b/Tests/AirwallexRiskTests/AirwallexRiskTests.swift
@@ -29,6 +29,10 @@ final class AirwallexRiskTests: XCTestCase {
         XCTAssertEqual(airwallexRisk.header.field, AirwallexKey.header)
         XCTAssertEqual(airwallexRisk.header.value, testContext.deviceID.wrappedValue.uuidString)
     }
+    
+    func testSessionID() {
+        XCTAssertEqual(airwallexRisk.sessionID, testContext.sessionID)
+    }
 
     func testSetAccountID() {
         let id = "accountID2"

--- a/Tests/AirwallexRiskTests/AirwallexRiskTests.swift
+++ b/Tests/AirwallexRiskTests/AirwallexRiskTests.swift
@@ -13,13 +13,13 @@ final class AirwallexRiskTests: XCTestCase {
     private var repository: EventRepository!
     private var testContext: AirwallexRiskContext!
     private var testEventManager: MockEventManager!
-    private var airwallexRisk: AirwallexRisk!
+    private var airwallexRisk: Risk!
 
     override func setUp() {
         repository = .init()
         testContext = .test()
         testEventManager = .init()
-        airwallexRisk = AirwallexRisk(
+        airwallexRisk = Risk(
             context: testContext,
             eventManager: testEventManager
         )

--- a/Tests/AirwallexRiskTests/EventManagerTests.swift
+++ b/Tests/AirwallexRiskTests/EventManagerTests.swift
@@ -100,13 +100,15 @@ private extension EventManager {
     static func manager(
         context: AirwallexRiskContext,
         repository: any RepositoryType<Event> = EventRepository(),
-        session: URLSession? = nil) -> EventManager {
-            let url = URL(string: "https://bws-staging.airwallex.com/bws/v2/m/\(context.sessionID.uuidString)")!
-            let session = session ?? .successMock(url: url, encodable: PostEventsResponse(message: "Success"))
-            return .init(
-                context: context,
-                repository: repository,
-                session: session
-            )
-        }
+        session: URLSession? = nil
+    ) -> EventManager {
+        let url = URL(string: "https://bws-staging.airwallex.com/bws/v2/m/\(context.sessionID.uuidString)")!
+        let session = session ?? .successMock(url: url, encodable: PostEventsResponse(message: "Success"))
+        return .init(
+            context: context,
+            repository: repository,
+            session: session,
+            timeInterval: 5
+        )
+    }
 }

--- a/Tests/AirwallexRiskTests/HeaderTests.swift
+++ b/Tests/AirwallexRiskTests/HeaderTests.swift
@@ -16,12 +16,12 @@ final class HeaderTests: XCTestCase {
     }
 
     func testSharedAirwallexHeaderNotStarted() {
-        XCTAssertNil(AirwallexRisk.header)
+        XCTAssertNil(Risk.header)
     }
 
     func testManualHeader() throws {
         let context = AirwallexRiskContext.test()
-        let risk = AirwallexRisk(
+        let risk = Risk(
             context: context,
             eventManager: MockEventManager()
         )

--- a/Tests/AirwallexRiskTests/ModelTests.swift
+++ b/Tests/AirwallexRiskTests/ModelTests.swift
@@ -16,8 +16,16 @@ final class ModelTests: XCTestCase {
     }
 
     func testTenant() {
-        XCTAssertEqual(Tenant.internal.rawValue, "Mobile app")
-        XCTAssertEqual(Tenant.pa.rawValue, "PA checkout")
-        XCTAssertEqual(Tenant.scale.rawValue, "Scale")
+        let encoder = JSONEncoder()
+        guard let inter = try? encoder.encode(Tenant.internal),
+              let pa = try? encoder.encode(Tenant.pa),
+              let scale = try? encoder.encode(Tenant.scale) else {
+            XCTFail("Encoding error")
+            return
+        }
+        
+        XCTAssert(String(data: inter, encoding: .utf8)?.contains("Mobile app") == true)
+        XCTAssert(String(data: pa, encoding: .utf8)?.contains("PA checkout") == true)
+        XCTAssert(String(data: scale, encoding: .utf8)?.contains("Scale") == true)
     }
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,7 @@
 sonar.projectKey=airwallex_airwallex-risk-ios
 sonar.projectName=Airwallex Risk iOS SDK
 sonar.sources=Sources
+sonar.exclusions=**/Risk+Shared.swift
 sonar.tests=Tests/AirwallexRiskTests
 sonar.swift.simulator=platform=iOS Simulator,name=iPhone 14,OS=16.0
 sonar.swift.project=Package.swift


### PR DESCRIPTION
This adds public methods/variable:
- sessionID
- AirwallexRiskConfiguration(environment: .staging, ..., bufferTimeInterval: 5)

Framework support:
- Compatibility with Objective C
- Action for .XCFramework build so it's compatible with Cocoapods projects
- Rename `AirwallexRisk` class as `Risk` to avoid ambiguous naming error when building .xcframework (can refer to [issue](https://github.com/swiftlang/swift/issues/56573) reported)