### PR TITLE
chore: fix missing -swift.h header for Objective-C integration

### DIFF
--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -11,32 +11,19 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Build .framework for iOS devices
+    - name: Install swift-create-xcframework tool
       run: |
-        BUILD_FOR_XCFRAMEWORK=true xcodebuild archive \
-          -scheme AirwallexRisk \
-          -sdk iphoneos \
-          -destination 'generic/platform=iOS' \
-          -archivePath './build/device.xcarchive' \
-          SKIP_INSTALL=NO \
-          BUILD_LIBRARY_FOR_DISTRIBUTION=YES
-
-    - name: Build .framework for iOS simulator
-      run: | 
-        BUILD_FOR_XCFRAMEWORK=true xcodebuild archive \
-          -scheme AirwallexRisk \
-          -sdk iphonesimulator \
-          -destination 'generic/platform=iOS Simulator' \
-          -archivePath './build/simulator.xcarchive' \
-          SKIP_INSTALL=NO \
-          BUILD_LIBRARY_FOR_DISTRIBUTION=YES
+        git clone https://github.com/unsignedapps/swift-create-xcframework.git \
+        cd swift-create-xcframework \
+        make install
 
     - name: Create XCFramework
+      run: swift create-xcframework --platform ios
+
+    - name: Copy resources
       run: |
-        xcodebuild -create-xcframework \
-          -framework ./build/device.xcarchive/Products/usr/local/lib/AirwallexRisk.framework \
-          -framework ./build/simulator.xcarchive/Products/usr/local/lib/AirwallexRisk.framework \
-          -output ./build/AirwallexRisk.xcframework
+        cp Sources/AirwallexRisk/Resources/* AirwallexRisk.xcframework/ios-arm64/AirwallexRisk.framework \
+        cp Sources/AirwallexRisk/Resources/* AirwallexRisk.xcframework/ios-arm64_x86_64-simulator/AirwallexRisk.framework
 
     - name: Upload XCFramework
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build-xcframework.yml
+++ b/.github/workflows/build-xcframework.yml
@@ -18,7 +18,7 @@ jobs:
         make install
 
     - name: Create XCFramework
-      run: swift create-xcframework --platform ios
+      run: swift create-xcframework --platform ios --xc-setting OTHER_SWIFT_FLAGS='-DCREATE_XCFRAMEWORK'
 
     - name: Copy resources
       run: |

--- a/AirwallexRiskExample/AirwallexRiskExample/AuthService.swift
+++ b/AirwallexRiskExample/AirwallexRiskExample/AuthService.swift
@@ -20,8 +20,8 @@ class AuthService {
     func login(username: String, password: String) -> User {
         // When the user logs in, set the user id and log the login event.
         let user = User(id: UUID().uuidString, username: username)
-        Risk.set(userID: user.id)
-        Risk.log(event: "login")
+        AirwallexRisk.set(userID: user.id)
+        AirwallexRisk.log(event: "login")
         return user
     }
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,7 @@
-// swift-tools-version: 5.8
+// swift-tools-version: 5.9
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
-import Foundation
-
-let buildForXCFramework = ProcessInfo.processInfo.environment["BUILD_FOR_XCFRAMEWORK"] == "true"
-let libraryType: Product.Library.LibraryType? = buildForXCFramework ? .dynamic : nil
 
 let package = Package(
     name: "AirwallexRisk",
@@ -15,7 +11,6 @@ let package = Package(
     products: [
         .library(
             name: "AirwallexRisk",
-            type: libraryType,
             targets: ["AirwallexRisk"]
         ),
     ],

--- a/Sources/AirwallexRisk/AirwallexRiskConfiguration.swift
+++ b/Sources/AirwallexRisk/AirwallexRiskConfiguration.swift
@@ -19,7 +19,7 @@ import Foundation
     /// - Parameters:
     ///   - isProduction: Set to false for pre-production or test builds.
     ///   - tenant: Do not modify unless requested by Airwallex.
-    public convenience init(
+    @objc public convenience init(
         isProduction: Bool = true,
         tenant: Tenant = .scale
     ) {
@@ -32,7 +32,7 @@ import Foundation
     /// - Parameters:
     ///   - environment: Airwallex risk environment, set to production for release builds.
     ///   - tenant: Airwallex risk SDK tenant.
-    public init(
+    @objc public init(
         environment: AirwallexRiskEnvironment = .production,
         tenant: Tenant = .scale,
         bufferTimeInterval: TimeInterval = 20

--- a/Sources/AirwallexRisk/DataCollector/Bundle+Values.swift
+++ b/Sources/AirwallexRisk/DataCollector/Bundle+Values.swift
@@ -20,11 +20,11 @@ extension Bundle {
     }
 
     static var sdkVersion: String? {
-        guard let path = Bundle.module.path(forResource: AirwallexKey.version, ofType: "json") else {
+        guard let url = Bundle(for: Risk.self).url(forResource: AirwallexKey.version, withExtension: "json") else {
             return nil
         }
         do {
-            let data = try Data(contentsOf: URL(fileURLWithPath: path), options: .mappedIfSafe)
+            let data = try Data(contentsOf: url, options: .mappedIfSafe)
             let result = try JSONSerialization.jsonObject(with: data, options: []) as? [String: String]
             return result?[AirwallexKey.version]
         } catch {

--- a/Sources/AirwallexRisk/DataCollector/Bundle+Values.swift
+++ b/Sources/AirwallexRisk/DataCollector/Bundle+Values.swift
@@ -20,7 +20,13 @@ extension Bundle {
     }
 
     static var sdkVersion: String? {
-        guard let url = Bundle(for: Risk.self).url(forResource: AirwallexKey.version, withExtension: "json") else {
+        #if CREATE_XCFRAMEWORK
+        let bundle = Bundle(for: Risk.self)
+        #else
+        let bundle = Bundle.module
+        #endif
+        
+        guard let url = bundle.url(forResource: AirwallexKey.version, withExtension: "json") else {
             return nil
         }
         do {

--- a/Sources/AirwallexRisk/Risk.swift
+++ b/Sources/AirwallexRisk/Risk.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public class Risk {
+@objc public class Risk: NSObject {
     private let context: AirwallexRiskContext
     private let eventManager: EventManagerType
 


### PR DESCRIPTION
This pr fixes the .xcframework generation:
- `xcodebuild archive` does not generate bridging header `Airwallex-Swift.h` for Objective-C usage
- Methods in `Risk.shared` are not visible to OC
- Type 'Bundle' has no member 'module', since it's only visible in Swift Package context